### PR TITLE
Directly register input driver

### DIFF
--- a/VDFaceTracking.cs
+++ b/VDFaceTracking.cs
@@ -1,7 +1,5 @@
 ﻿using FrooxEngine;
 using ResoniteModLoader;
-using System;
-using System.Threading;
 
 namespace VDFaceTracking
 {


### PR DESCRIPTION
Remove harmony being needed, instead directly registers the input driver. This fix is compatible in the current main release and fixes the mod for pre-release