### PR TITLE
.NET 9 Compatibility

### DIFF
--- a/VDProxy.cs
+++ b/VDProxy.cs
@@ -301,7 +301,7 @@ namespace VDFaceTracking
             cancellationTokenSource.Cancel();
 
             if (thread != null)
-                thread.Abort();
+                thread.Interrupt();
 
             cancellationTokenSource.Dispose();
 


### PR DESCRIPTION
### Summary
Fixes an issue where the mod prevented the game from shutting down properly.
The shutdown sequence failed because the thread could not be aborted, leading to a crash.

### Details
On .NET 9 Core Thread.Abort() is not supported, attempting to call it throws a System.PlatformNotSupportedException. This caused the shutdown process to hang and the game to fail closing cleanly.

### Exception
```
System.PlatformNotSupportedException: Thread abort is not supported on this platform.
   at System.Threading.Thread.Abort()
   at VDFaceTracking.VDProxy.Teardown()
   at VDFaceTracking.VDFaceTracking.<>c.<OnEngineInit>b__17_1()
   at DMD<DMD<>?38236068::FrooxEngine.Engine::RequestShutdown>(Engine this)
   at SyncProxy<System.Void FrooxEngine.Engine:RequestShutdown()>(Engine )
   at FrooxEngine.AppEnder.OnCommonUpdate() in D:\Workspace\Everion\FrooxEngine\FrooxEngine\Userspace\Userspace\AppEnder.cs:line 117
   at FrooxEngine.UpdateManager.RunUpdates() in D:\Workspace\Everion\FrooxEngine\FrooxEngine\Data Model\Controllers\UpdateManager.cs:line 459```